### PR TITLE
make pods satisfy different host ports

### DIFF
--- a/pkg/networking/trafficplugin/loadbalancer/consistenthash/serviceinstance.go
+++ b/pkg/networking/trafficplugin/loadbalancer/consistenthash/serviceinstance.go
@@ -41,7 +41,7 @@ func (h defaultHasher) Sum64(data []byte) uint64 {
 type ServiceInstance struct {
 	Namespace  string
 	Name       string
-	InstanceIP string // TODO: Now it is host ip, and later it will be pod ip@Poorunga
+	InstanceIP string
 }
 
 // String gets service instance key
@@ -81,7 +81,7 @@ func CreateHashRingByService(svc *v1.Service) {
 			instances = append(instances, ServiceInstance{
 				Namespace:  svc.Namespace,
 				Name:       svc.Name,
-				InstanceIP: p.Status.HostIP,
+				InstanceIP: p.Status.PodIP,
 			})
 		}
 	}
@@ -156,7 +156,7 @@ func lookForDifference(hr *hashring.Consistent, pods []*v1.Pod, key string) ([]s
 			continue
 		}
 		if p.Status.Phase == v1.PodRunning {
-			key := fmt.Sprintf("%s#%s#%s", namespace, name, p.Status.HostIP)
+			key := fmt.Sprintf("%s#%s#%s", namespace, name, p.Status.PodIP)
 			dest = append(dest, key)
 		}
 	}


### PR DESCRIPTION
When hostport is different , the result hostport of curl is from pods[0]，not the pod itself. I think it should support different host pods at the same time. And while pods running at one node, for load balancing “consistentHash”,  hostIP is all the same but portIP is unique, so I replace the hostIP with the portIP.
![1cc2370d4069b8ae638ff7c44cef77d](https://user-images.githubusercontent.com/71764707/122539618-5f556c80-d05a-11eb-8094-5dd569e1b80a.png)
![a0b4719b9e54b7a7335420c208513e1](https://user-images.githubusercontent.com/71764707/122539685-71cfa600-d05a-11eb-9465-cf5f510e98e8.png)
