### PR TITLE
DestinationRule host should consistent with service name

### DIFF
--- a/examples/hostname-lb-random-gateway-route.yaml
+++ b/examples/hostname-lb-random-gateway-route.yaml
@@ -68,7 +68,7 @@ metadata:
   name: hostname-lb-svc
   namespace: edgemesh-test
 spec:
-  host: hostname-lb-edge
+  host: hostname-lb-svc
   trafficPolicy:
     loadBalancer:
       simple: RANDOM

--- a/examples/hostname-lb-random-gateway-tls.yaml
+++ b/examples/hostname-lb-random-gateway-tls.yaml
@@ -81,10 +81,10 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: hostname-lb-edge
+  name: hostname-lb-svc
   namespace: edgemesh-test
 spec:
-  host: hostname-lb-edge
+  host: hostname-lb-svc
   trafficPolicy:
     loadBalancer:
       simple: RANDOM

--- a/examples/hostname-lb-random-gateway.yaml
+++ b/examples/hostname-lb-random-gateway.yaml
@@ -65,10 +65,10 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: hostname-lb-edge
+  name: hostname-lb-svc
   namespace: edgemesh-test
 spec:
-  host: hostname-lb-edge
+  host: hostname-lb-svc
   trafficPolicy:
     loadBalancer:
       simple: RANDOM

--- a/examples/hostname-lb-random.yaml
+++ b/examples/hostname-lb-random.yaml
@@ -52,7 +52,7 @@ metadata:
   name: hostname-lb-svc
   namespace: edgemesh-test
 spec:
-  host: hostname-lb-edge
+  host: hostname-lb-svc
   trafficPolicy:
     loadBalancer:
       simple: RANDOM


### PR DESCRIPTION
DestinationRule 的 host 要和 service 的name 保持一致， edgemesh 通过service name 查找的对应的负载均衡规则。