### PR TITLE
fix missing strategy lock

### DIFF
--- a/agent/pkg/dns/module.go
+++ b/agent/pkg/dns/module.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"net"
 
+	mdns "github.com/miekg/dns"
+
 	"github.com/kubeedge/beehive/pkg/core"
 	"github.com/kubeedge/edgemesh/agent/pkg/dns/config"
 	"github.com/kubeedge/edgemesh/agent/pkg/dns/controller"
 	"github.com/kubeedge/edgemesh/common/informers"
 	"github.com/kubeedge/edgemesh/common/modules"
 	"github.com/kubeedge/edgemesh/common/util"
-
-	mdns "github.com/miekg/dns"
 )
 
 // EdgeDNS is a node-level dns resolver

--- a/agent/pkg/tunnel/module.go
+++ b/agent/pkg/tunnel/module.go
@@ -3,11 +3,11 @@ package tunnel
 import (
 	"context"
 	"fmt"
-	"k8s.io/klog/v2"
 
 	"github.com/libp2p/go-libp2p"
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	"github.com/libp2p/go-libp2p-core/host"
+	"k8s.io/klog/v2"
 
 	"github.com/kubeedge/beehive/pkg/core"
 	"github.com/kubeedge/edgemesh/agent/pkg/tunnel/config"


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>
`Strategy` struct has `sync.Mutex` to protect slice `instances` read/write
And some codes don't lock mutex to protect read/write. So add missing lock
And `return s.instances[i], nil` also need lock, so refactor `pick` function to return instance directly
