### PR TITLE
Patch missing kubeconfig

### DIFF
--- a/build/agent/kubernetes/edgemesh-agent/04-daemonset.yaml
+++ b/build/agent/kubernetes/edgemesh-agent/04-daemonset.yaml
@@ -45,6 +45,9 @@ spec:
               cpu: 100m
               memory: 128Mi
           volumeMounts:
+            - name: config
+              mountPath: /root/.kube/config
+              readOnly: true
             - name: conf
               mountPath: /etc/kubeedge/config
             - name: resolv
@@ -52,6 +55,10 @@ spec:
             - name: edgemesh
               mountPath: /etc/kubeedge/edgemesh
       volumes:
+        - name: config
+          hostPath:
+            path: "/root/.kube/config"
+            type: File
         - name: conf
           configMap:
             name: edgemesh-agent-cfg

--- a/build/server/edgemesh/05-configmap.yaml
+++ b/build/server/edgemesh/05-configmap.yaml
@@ -8,6 +8,11 @@ metadata:
     kubeedge: edgemesh-server
 data:
   edgemesh-server.yaml: |
+    kubeAPIConfig:
+      burst: 200
+      contentType: application/vnd.kubernetes.protobuf
+      kubeConfig: "/root/.kube/config"
+      qps: 100
     modules:
       tunnel:
         enable: true

--- a/build/server/edgemesh/06-deployment.yaml
+++ b/build/server/edgemesh/06-deployment.yaml
@@ -40,6 +40,9 @@ spec:
             cpu: 100m
             memory: 512Mi
         volumeMounts:
+          - name: config
+            mountPath: /root/.kube/config
+            readOnly: true
           - name: conf
             mountPath: /etc/kubeedge/config
           - name: edgemesh
@@ -47,6 +50,10 @@ spec:
       restartPolicy: Always
       serviceAccountName: edgemesh-server
       volumes:
+        - name: config
+          hostPath:
+            path: "/root/.kube/config"
+            type: File
         - name: conf
           configMap:
             name: edgemesh-server
@@ -54,5 +61,3 @@ spec:
           hostPath:
             path: /etc/kubeedge/edgemesh
             type: DirectoryOrCreate
-
-


### PR DESCRIPTION
Edit `edgemesh-agent` and `edgemesh-server` YAML files to mount the local `kubeconfig` file into the respective pods.