### PR TITLE
fix connection resource leak

### DIFF
--- a/agent/pkg/chassis/loadbalancer/consistenthash/hashring/serviceinstance.go
+++ b/agent/pkg/chassis/loadbalancer/consistenthash/hashring/serviceinstance.go
@@ -41,7 +41,7 @@ type ServiceInstance struct {
 
 // String gets service instance key
 func (si ServiceInstance) String() string {
-	// key format: Namespace.Name.InstanceIP
+	// key format: Namespace#Name#InstanceIP
 	return fmt.Sprintf("%s#%s#%s", si.Namespace, si.Name, si.InstanceIP)
 }
 


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>

as long as connection is created successfully, we should `Close` it.
And in source codes, we should all use `sync.Once` to protect connection is closed only once a time.