### PR TITLE
when error, cannot print success logs

### DIFF
--- a/server/pkg/tunnel/tunnel.go
+++ b/server/pkg/tunnel/tunnel.go
@@ -17,6 +17,7 @@ func (t *TunnelServer) Run() {
 	err := controller.APIConn.SetPeerAddrInfo(constants.ServerAddrName, host.InfoFromHost(t.Host))
 	if err != nil {
 		klog.Errorf("failed update [%s] addr %v to secret: %v", constants.ServerAddrName, t.Host.Addrs(), err)
+		return
 	}
 	klog.Infof("success update [%s] addr %v to secret", constants.ServerAddrName, t.Host.Addrs())
 }


### PR DESCRIPTION
Signed-off-by: gy95 <1015105054@qq.com>
when update secrets failed, can't print success related logs: `"success update [%s] addr %v to secret", constants.ServerAddrName, t.Host.Addrs()` 
So need `return` the function