### PR TITLE
Added a label: proxyby=edgemesh for services that require cloud-side communication.

### DIFF
--- a/agent/pkg/proxy/iptables.go
+++ b/agent/pkg/proxy/iptables.go
@@ -20,7 +20,12 @@ import (
 	"github.com/kubeedge/edgemesh/common/util"
 )
 
-const meshRootChain utiliptables.Chain = "EDGE-MESH"
+const (
+	meshRootChain      utiliptables.Chain = "EDGE-MESH"
+	None                                  = "None"
+	labelCoreDNS                          = "k8s-app=kube-dns"
+	labelProxyEdgeMesh                    = "proxyby!=edgemesh"
+)
 
 type iptablesEnsureInfo struct {
 	table     utiliptables.Table
@@ -69,9 +74,6 @@ func NewProxier(subnet string, protoProxies []protocol.ProtoProxy, kubeClient ku
 
 	// iptables rule cleaning and writing
 	proxier.CleanResidue()
-	if err = proxier.InitRules(); err != nil {
-		return proxier, err
-	}
 	proxier.FlushRules()
 	proxier.EnsureRules()
 
@@ -85,6 +87,7 @@ func (proxier *Proxier) Start() {
 		for {
 			select {
 			case <-ticker.C:
+				proxier.FlushRules()
 				proxier.EnsureRules()
 			case <-beehiveContext.Done():
 				proxier.FlushRules()
@@ -94,29 +97,32 @@ func (proxier *Proxier) Start() {
 	}()
 }
 
-func (proxier *Proxier) InitRules() (err error) {
-	proxier.mu.Lock()
-	defer proxier.mu.Unlock()
-
-	proxier.ignoreRules, err = proxier.createIgnoreRules()
-	if err != nil {
-		return fmt.Errorf("failed to create ignore rules: %v", err)
-	} else {
-		klog.V(5).Infof("ignore rules: %v", proxier.ignoreRules)
-	}
-
-	proxier.proxyRules, proxier.dnatRules = proxier.createProxyRules()
-	klog.V(5).Infof("proxy rules: %v", proxier.proxyRules)
-	klog.V(5).Infof("dnat rules: %v", proxier.dnatRules)
-
-	return nil
-}
-
-func ignoreRuleByService(svc *corev1.Service) iptablesEnsureInfo {
+func (proxier *Proxier) ignoreRuleByService(svc *corev1.Service) iptablesEnsureInfo {
 	var (
 		ruleExtraArgs = func(svc *corev1.Service) []string {
-			dst := fmt.Sprintf("%s/32", svc.Spec.ClusterIP)
-			return []string{"-d", dst}
+			// Headless Service
+			switch svc.Spec.ClusterIP {
+			case None:
+				endpoints, err := proxier.kubeClient.CoreV1().Endpoints(svc.Namespace).Get(context.Background(), svc.Name, metav1.GetOptions{})
+				if err != nil {
+					klog.Errorf("get the endpoints %s failed: %v", strings.Join([]string{svc.Namespace, svc.Name}, "."), err)
+					return nil
+				}
+				endpointIPs := []string{None}
+				for _, endpointSubset := range endpoints.Subsets {
+					epSubset := endpointSubset
+					for _, endpointAddress := range epSubset.Addresses {
+						epAddress := endpointAddress
+						klog.V(4).Infof("eps: %s.%s, endpointAddress.IP:%s", endpoints.Namespace, endpoints.Name, epAddress.IP)
+						endpointIPs = append(endpointIPs, epAddress.IP)
+					}
+				}
+				return endpointIPs
+			default:
+				// cluster ip
+				dst := fmt.Sprintf("%s/32", svc.Spec.ClusterIP)
+				return []string{"-d", dst}
+			}
 		}
 
 		ruleComment = func(svc *corev1.Service) string {
@@ -134,21 +140,53 @@ func ignoreRuleByService(svc *corev1.Service) iptablesEnsureInfo {
 
 // createIgnoreRules exclude some services that must be ignored
 func (proxier *Proxier) createIgnoreRules() (ignoreRules []iptablesEnsureInfo, err error) {
+	ignoreRulesIptablesEnsureMap := make(map[string]*corev1.Service)
 	// kube-apiserver service
 	kubeAPI, err := proxier.kubeClient.CoreV1().Services("default").Get(context.Background(), "kubernetes", metav1.GetOptions{})
 	if err != nil {
 		return
 	}
-	ignoreRules = append(ignoreRules, ignoreRuleByService(kubeAPI))
+	ignoreRulesIptablesEnsureMap[strings.Join([]string{kubeAPI.Namespace, kubeAPI.Name}, ".")] = kubeAPI
 
 	// kube-dns service
 	kubeDNS, err := proxier.kubeClient.CoreV1().Services("kube-system").Get(context.Background(), "kube-dns", metav1.GetOptions{})
 	if err != nil {
-		return
+		klog.Warningf("get kube-dns service failed, your cluster may be not have kube-dns service: %s", err)
 	}
-	ignoreRules = append(ignoreRules, ignoreRuleByService(kubeDNS))
+	if kubeDNS != nil && err == nil {
+		klog.V(4).Infof("ignored kubeDNS: %s", kubeDNS.Name)
+		ignoreRulesIptablesEnsureMap[strings.Join([]string{kubeDNS.Namespace, kubeDNS.Name}, ".")] = kubeDNS
+	}
+
+	// coredns service
+	kubeDNSList, err := proxier.kubeClient.CoreV1().Services("kube-system").List(context.Background(), metav1.ListOptions{LabelSelector: labelCoreDNS})
+	if err != nil {
+		klog.Warningf("get coredns service failed, your cluster may be not have coredns service: %s", err)
+	}
+	if err == nil && kubeDNSList != nil && len(kubeDNSList.Items) > 0 {
+		for _, item := range kubeDNSList.Items {
+			coreDNS := item
+			klog.V(4).Infof("ignored containing k8s-app=kube-dns label service: %s", coreDNS.Name)
+			ignoreRulesIptablesEnsureMap[strings.Join([]string{item.Namespace, item.Name}, ".")] = &coreDNS
+		}
+	}
 
 	// Other services we want to ignore...
+	otherIgnoreServiceList, err := proxier.kubeClient.CoreV1().Services("").List(context.Background(), metav1.ListOptions{LabelSelector: labelProxyEdgeMesh})
+	if err != nil {
+		klog.Warningf("get Other ignore service failed: %s", err)
+	}
+	if err == nil && otherIgnoreServiceList != nil && len(otherIgnoreServiceList.Items) > 0 {
+		for _, item := range otherIgnoreServiceList.Items {
+			otherIgnoreService := item
+			klog.V(4).Infof("ignored not containing proxyby=edgemesh label service: %s", otherIgnoreService.Name)
+			ignoreRulesIptablesEnsureMap[strings.Join([]string{item.Namespace, item.Name}, ".")] = &otherIgnoreService
+		}
+	}
+
+	for _, service := range ignoreRulesIptablesEnsureMap {
+		ignoreRules = append(ignoreRules, proxier.ignoreRuleByService(service))
+	}
 
 	return ignoreRules, nil
 }
@@ -197,6 +235,7 @@ func (proxier *Proxier) createProxyRules() (proxyRules, dnatRules []iptablesEnsu
 
 // ensureRule ensures iptables rules exist
 func (proxier *Proxier) EnsureRules() {
+	var err error
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()
 
@@ -216,17 +255,44 @@ func (proxier *Proxier) EnsureRules() {
 		}
 	}
 
+	// recollect need to ignore rules
+	proxier.ignoreRules, err = proxier.createIgnoreRules()
+	if err != nil {
+		klog.Errorf("failed to create ignore rules: %v", err)
+	} else {
+		klog.V(5).Infof("ignore rules: %v", proxier.ignoreRules)
+	}
+
 	// ensure ignore rules
 	for _, rule := range proxier.ignoreRules {
-		args := append(rule.extraArgs,
-			"-m", "comment", "--comment", rule.comment,
-			"-j", string(rule.dstChain),
-		)
-		if _, err := proxier.iptables.EnsureRule(utiliptables.Append, rule.table, rule.srcChain, args...); err != nil {
-			klog.ErrorS(err, "Failed to ensure ignore rules", "table", rule.table, "srcChain", rule.srcChain, "dstChain", rule.dstChain)
-			return
+		if rule.extraArgs[0] == None {
+			headLessIps := rule.extraArgs[1:]
+			if len(headLessIps) > 0 {
+				for _, headLessIp := range headLessIps {
+					hlIp := headLessIp
+					args := append([]string{"-d"}, fmt.Sprintf("%s/32", hlIp), "-m", "comment", "--comment", rule.comment, "-j", string(rule.dstChain))
+					if _, err := proxier.iptables.EnsureRule(utiliptables.Append, rule.table, rule.srcChain, args...); err != nil {
+						klog.ErrorS(err, "Failed to ensure ignore rules", "table", rule.table, "srcChain", rule.srcChain, "dstChain", rule.dstChain)
+						return
+					}
+				}
+			}
+		} else {
+			args := append(rule.extraArgs,
+				"-m", "comment", "--comment", rule.comment,
+				"-j", string(rule.dstChain),
+			)
+			if _, err := proxier.iptables.EnsureRule(utiliptables.Append, rule.table, rule.srcChain, args...); err != nil {
+				klog.ErrorS(err, "Failed to ensure ignore rules", "table", rule.table, "srcChain", rule.srcChain, "dstChain", rule.dstChain)
+				return
+			}
 		}
 	}
+
+	// recollect need to proxy rules
+	proxier.proxyRules, proxier.dnatRules = proxier.createProxyRules()
+	klog.V(5).Infof("proxy rules: %v", proxier.proxyRules)
+	klog.V(5).Infof("dnat rules: %v", proxier.dnatRules)
 
 	// ensure proxy rules
 	for _, jump := range proxier.proxyRules {

--- a/go.sum
+++ b/go.sum
@@ -323,7 +323,6 @@ github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6m
 github.com/go-redis/redis v6.14.2+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
-github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/goburrow/serial v0.1.0/go.mod h1:sAiqG0nRVswsm1C97xsttiYCzSLBmUZ/VSlVLZJ8haA=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -877,7 +876,6 @@ github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h
 github.com/naoina/toml v0.1.1/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/neelance/astrewrite v0.0.0-20160511093645-99348263ae86/go.mod h1:kHJEU3ofeGjhHklVoIGuVj85JJwZ6kWPaJwCIxgnFmo=
 github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a/Q4r9LP1IltGz7tA7iOK1WonHEYhu1HRBA7ZiM=
-github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -890,7 +888,6 @@ github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
-github.com/onsi/ginkgo v1.14.0 h1:2mOpI4JVVPBN+WQRa0WKH2eXR+Ey+uK4n7Zj0aYpIQA=
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
Problems with accessing external services through edgemesh at the edge
Which issue(s) this PR fixes:

Fixes #67 
https://github.com/kubeedge/edgemesh/pull/66#issuecomment-908964875

Special notes for your reviewer:
1. The ignoreRulesIptablesEnsureMap used for heavy processing was added to the createIgnoreRules function before, and there is a for range reference problem;
2. Added a label: `proxyby=edgemesh` for services that require cloud-side communication. The intent is that services without this label still use kube-proxy for routing;
3. In the EnsureRules function, the process of re-refresh creation of ignoring rules and proxy rules has been added, otherwise changes over time may lead to untimely route refresh and increase the load of edgemesh;
4. The ignoreRuleByService is stored in Proxier, which is mainly used to obtain the addresses of endpoints. The intention is to return the Headless service traffic hijacked by edgemesh to kube-proxy;

Does this PR introduce a user-facing change?:
Added a label: `proxyby=edgemesh` for services that require cloud-side communication. 
Signed-off-by: 胡正阳 <huzhengyang@gridsum.com>