### PR TITLE
fix dns domain resolve bug

### DIFF
--- a/agent/pkg/dns/dns.go
+++ b/agent/pkg/dns/dns.go
@@ -64,6 +64,10 @@ func (dns *EdgeDNS) Run() {
 
 // lookup confirms if the service exists
 func lookup(serviceURL string) (ip string, exist bool) {
+	// Here serviceURL is a domain name which has at least a "." suffix. So here we need trim it.
+	if strings.HasSuffix(serviceURL, ".") {
+		serviceURL = strings.TrimSuffix(serviceURL, ".")
+	}
 	name, namespace := util.SplitServiceKey(serviceURL)
 	ip, err := controller.APIConn.GetSvcIP(namespace, name)
 	if err != nil {


### PR DESCRIPTION
Problem: When resolve a domain name like "svc-name", edgemesh cannot correctly work.

Expect: When resolve a domain name like "svc-name", edgemesh should treat it as "svc-name.default", just like kubernetes.