### PR TITLE
support consistentHash when pods distributed in different nodes in same podIP  

### DIFF
--- a/agent/pkg/chassis/controller/controller.go
+++ b/agent/pkg/chassis/controller/controller.go
@@ -172,9 +172,9 @@ func (c *ChassisController) createHashRing(namespace, name string) {
 	for _, subset := range eps.Subsets {
 		for _, addr := range subset.Addresses {
 			instances = append(instances, hashring.ServiceInstance{
-				Namespace:  namespace,
-				Name:       name,
-				InstanceIP: addr.IP,
+				Namespace:    namespace,
+				Name:         name,
+				InstanceName: addr.TargetRef.Name,
 			})
 		}
 	}
@@ -216,9 +216,9 @@ func (c *ChassisController) updateHashRing(eps *v1.Endpoints) {
 			continue
 		}
 		hr.Add(hashring.ServiceInstance{
-			Namespace:  namespace,
-			Name:       name,
-			InstanceIP: instanceIP,
+			Namespace:    namespace,
+			Name:         name,
+			InstanceName: instanceIP,
 		})
 	}
 	for _, key := range deleted {
@@ -250,7 +250,7 @@ func findDiff(eps *v1.Endpoints, hr *consistent.Consistent) ([]string, []string)
 	// build destination array from endpoints
 	for _, subset := range eps.Subsets {
 		for _, addr := range subset.Addresses {
-			dest = append(dest, fmt.Sprintf("%s#%s#%s", eps.Namespace, eps.Name, addr.IP))
+			dest = append(dest, fmt.Sprintf("%s#%s#%s", eps.Namespace, eps.Name, addr.TargetRef.Name))
 		}
 	}
 	klog.V(4).Infof("dest: %+v", dest)

--- a/agent/pkg/chassis/loadbalancer/consistenthash/hashring/serviceinstance.go
+++ b/agent/pkg/chassis/loadbalancer/consistenthash/hashring/serviceinstance.go
@@ -35,18 +35,18 @@ func (h defaultHasher) Sum64(data []byte) uint64 {
 
 // ServiceInstance is the implementation of the consistent.Member interface
 type ServiceInstance struct {
-	Namespace  string
-	Name       string
-	InstanceIP string
+	Namespace    string
+	Name         string
+	InstanceName string
 }
 
 // String gets service instance key
 func (si ServiceInstance) String() string {
-	// key format: Namespace#Name#InstanceIP
-	return fmt.Sprintf("%s#%s#%s", si.Namespace, si.Name, si.InstanceIP)
+	// key format: Namespace#Name#InstanceName
+	return fmt.Sprintf("%s#%s#%s", si.Namespace, si.Name, si.InstanceName)
 }
 
-func SplitKey(key string) (namespace, name, instanceIP string, err error) {
+func SplitKey(key string) (namespace, name, instanceName string, err error) {
 	parts := strings.Split(key, "#")
 	if len(parts) != 3 {
 		err = fmt.Errorf("invalid ServiceInstance key format")

--- a/agent/pkg/chassis/registry/registry.go
+++ b/agent/pkg/chassis/registry/registry.go
@@ -108,7 +108,7 @@ func (esd *EdgeServiceDiscovery) FindMicroServiceInstances(consumerID, microServ
 
 				microServiceInstances = append(microServiceInstances, &registry.MicroServiceInstance{
 					InstanceID:   fmt.Sprintf("%s.%s|%s.%d", namespace, name, addr.IP, targetPort),
-					ServiceID:    fmt.Sprintf("%s#%s#%s", namespace, name, addr.IP),
+					ServiceID:    fmt.Sprintf("%s#%s#%s", namespace, name, addr.TargetRef.Name),
 					HostName:     "",
 					EndpointsMap: map[string]string{proto: fmt.Sprintf("%s:%s:%d", *addr.NodeName, addr.IP, targetPort)},
 				})


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:
As shown below，podIP can be same, but consistentHash use podIP as the key to get instance, so I choose PodName instead.
![image](https://user-images.githubusercontent.com/71764707/142412836-71c3241d-0925-4bbe-98b8-ebb28da0ac0e.png)
