### PR TITLE
fix wrong annotation of map 	ipBySvc  

### DIFF
--- a/agent/pkg/proxy/controller/controller.go
+++ b/agent/pkg/proxy/controller/controller.go
@@ -26,7 +26,7 @@ type ProxyController struct {
 
 	sync.RWMutex
 	svcPortsByIP map[string]string // key: clusterIP, value: SvcPorts
-	ipBySvc      map[string]string // key: svcName.svcNamespace, value: clusterIP
+	ipBySvc      map[string]string // key: svcNamespace.svcName, value: clusterIP
 }
 
 func Init(ifm *informers.Manager) {


### PR DESCRIPTION
For map 	ipBySvc , key should be svcNamespace.svcName instead of  svcName.svcNamespace