### PR TITLE
If kubeAPIConfig is configured, the value prefer to user’s

### DIFF
--- a/build/agent/kubernetes/edgemesh-agent/05-configmap.yaml
+++ b/build/agent/kubernetes/edgemesh-agent/05-configmap.yaml
@@ -14,12 +14,6 @@ data:
       dummyDeviceName: edgemesh0
       dummyDeviceIP: 169.254.96.16
       configMapName: edgemesh-agent-cfg
-    kubeAPIConfig:
-      burst: 200
-      contentType: application/vnd.kubernetes.protobuf
-      kubeConfig: ""
-      master: ""
-      qps: 100
     goChassisConfig:
       protocol:
         tcpBufferSize: 8192

--- a/build/agent/kubernetes/edgemesh-gateway/02-configmap.yaml
+++ b/build/agent/kubernetes/edgemesh-gateway/02-configmap.yaml
@@ -14,12 +14,6 @@ data:
       dummyDeviceName: edgemesh0
       dummyDeviceIP: 169.254.96.16
       configMapName: edgemesh-gateway-cfg
-    kubeAPIConfig:
-      burst: 200
-      contentType: application/vnd.kubernetes.protobuf
-      kubeConfig: ""
-      master: ""
-      qps: 100
     goChassisConfig:
       protocol:
         tcpBufferSize: 8192

--- a/build/helm/edgemesh/charts/agent/values.yaml
+++ b/build/helm/edgemesh/charts/agent/values.yaml
@@ -7,12 +7,6 @@ commonConfig:
   dummyDeviceName: edgemesh0
   dummyDeviceIP: 169.254.96.16
   configMapName: edgemesh-agent-cfg
-kubeAPIConfig:
-  burst: 200
-  contentType: application/vnd.kubernetes.protobuf
-  kubeConfig: ""
-  master: ""
-  qps: 100
 goChassisConfig:
   protocol:
     tcpBufferSize: 8192

--- a/build/helm/gateway/values.yaml
+++ b/build/helm/gateway/values.yaml
@@ -8,12 +8,6 @@ commonConfig:
   dummyDeviceName: edgemesh0
   dummyDeviceIP: 169.254.96.16
   configMapName: edgemesh-gateway-cfg
-kubeAPIConfig:
-  burst: 200
-  contentType: application/vnd.kubernetes.protobuf
-  kubeConfig: ""
-  master: ""
-  qps: 100
 goChassisConfig:
   protocol:
     tcpBufferSize: 8192


### PR DESCRIPTION
Befor: No matter the kubeAPIConfig.Master is set, it equals "http://127.0.0.1:10550" alwaysly.

Now：Only when the kubeAPIConfig.Master is not configured, it will be defaults.