### PR TITLE
Fix log's capitalization in tunnel module

### DIFF
--- a/agent/pkg/tunnel/controller/controller.go
+++ b/agent/pkg/tunnel/controller/controller.go
@@ -46,12 +46,12 @@ func Init(ifm *informers.Manager) *TunnelAgentController {
 func (c *TunnelAgentController) GetPeerAddrInfo(nodeName string) (info *peer.AddrInfo, err error) {
 	secret, err := c.secretLister.Secrets(constants.SecretNamespace).Get(constants.SecretName)
 	if err != nil {
-		return nil, fmt.Errorf("Get %s addr from api server err: %v", nodeName, err)
+		return nil, fmt.Errorf("get %s addr from api server err: %w", nodeName, err)
 	}
 
 	infoBytes := secret.Data[nodeName]
 	if len(infoBytes) == 0 {
-		return nil, fmt.Errorf("Get %s addr from api server err: %v", nodeName, err)
+		return nil, fmt.Errorf("get %s addr from api server err: %w", nodeName, err)
 	}
 
 	info = new(peer.AddrInfo)
@@ -66,12 +66,12 @@ func (c *TunnelAgentController) GetPeerAddrInfo(nodeName string) (info *peer.Add
 func (c *TunnelAgentController) SetPeerAddrInfo(nodeName string, info *peer.AddrInfo) error {
 	peerAddrINfoBytes, err := info.MarshalJSON()
 	if err != nil {
-		return fmt.Errorf("Marshal node %s peer info err: %v", nodeName, err)
+		return fmt.Errorf("marshal node %s peer info err: %w", nodeName, err)
 	}
 
 	secret, err := c.secretLister.Secrets(constants.SecretNamespace).Get(constants.SecretName)
 	if err != nil {
-		return fmt.Errorf("Get secret %s in %s failed: %v", constants.SecretName, constants.SecretNamespace, err)
+		return fmt.Errorf("get secret %s in %s failed: %w", constants.SecretName, constants.SecretNamespace, err)
 	}
 
 	if secret.Data == nil {
@@ -83,7 +83,7 @@ func (c *TunnelAgentController) SetPeerAddrInfo(nodeName string, info *peer.Addr
 	secret.Data[nodeName] = peerAddrINfoBytes
 	secret, err = c.secretOperator.Update(context.Background(), secret, metav1.UpdateOptions{})
 	if err != nil {
-		return fmt.Errorf("Update secret %v err: %v", secret, err)
+		return fmt.Errorf("update secret %v err: %w", secret, err)
 	}
 	return nil
 }

--- a/agent/pkg/tunnel/protocol/tcp/tcpproxy.go
+++ b/agent/pkg/tunnel/protocol/tcp/tcpproxy.go
@@ -108,7 +108,7 @@ func (tp *TCPProxyService) ProxyStreamHandler(s network.Stream) {
 func (tp *TCPProxyService) GetProxyStream(targetNodeName, targetIP string, targetPort int32) (io.ReadWriteCloser, error) {
 	destInfo, err := controller.APIConn.GetPeerAddrInfo(targetNodeName)
 	if err != nil {
-		return nil, fmt.Errorf("Get %s addr err: %v", targetNodeName, err)
+		return nil, fmt.Errorf("get %s addr err: %w", targetNodeName, err)
 	}
 
 	connNum := tp.host.Network().ConnsToPeer(destInfo.ID)
@@ -125,7 +125,7 @@ func (tp *TCPProxyService) GetProxyStream(targetNodeName, targetIP string, targe
 
 	stream, err := tp.host.NewStream(context.Background(), destInfo.ID, TCPProxyProtocol)
 	if err != nil {
-		return nil, fmt.Errorf("New stream between %s err: %v", targetNodeName, err)
+		return nil, fmt.Errorf("new stream between %s err: %w", targetNodeName, err)
 	}
 
 	streamWriter := protoio.NewDelimitedWriter(stream)
@@ -141,23 +141,23 @@ func (tp *TCPProxyService) GetProxyStream(targetNodeName, targetIP string, targe
 	if err = streamWriter.WriteMsg(msg); err != nil {
 		err = stream.Reset()
 		if err != nil {
-			return nil, fmt.Errorf("Stream between %s reset err: %v", targetNodeName, err)
+			return nil, fmt.Errorf("stream between %s reset err: %w", targetNodeName, err)
 		}
-		return nil, fmt.Errorf("Write conn msg to %s err: %v", targetNodeName, err)
+		return nil, fmt.Errorf("write conn msg to %s err: %w", targetNodeName, err)
 	}
 
 	msg.Reset()
 	if err = streamReader.ReadMsg(msg); err != nil {
 		err1 := stream.Reset()
 		if err1 != nil {
-			return nil, fmt.Errorf("Stream between %s reset err: %w", targetNodeName, err1)
+			return nil, fmt.Errorf("stream between %s reset err: %w", targetNodeName, err1)
 		}
-		return nil, fmt.Errorf("Read conn result msg from %s err: %v", targetNodeName, err)
+		return nil, fmt.Errorf("read conn result msg from %s err: %w", targetNodeName, err)
 	}
 	if msg.GetType() == tcp_pb.TCPProxy_FAILED {
 		err = stream.Reset()
 		if err != nil {
-			return nil, fmt.Errorf("Stream between %s reset err: %v", targetNodeName, err)
+			return nil, fmt.Errorf("stream between %s reset err: %w", targetNodeName, err)
 		}
 		return nil, fmt.Errorf("%s dial %s:%d err: TCPProxy.type is TCPProxy_FAILED", targetNodeName, targetIP, targetPort)
 	}


### PR DESCRIPTION
Signed-off-by: lvchenggang <lvchenggang_yewu@cmss.chinamobile.com>

Error strings of fmt.Errorf() should not be capitalized:
    1) the IDE will prompt: "Error string should not be capitalized or end with punctuation".
    2) since these logs are usually printed following other context, so with additional capital letters in log does not apply to logging.