### PR TITLE
delete the prerequisites part in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,6 @@ The core components of EdgeMesh-Agent include:
 
 ## Guides
 
-### Prerequisites
-Before using EdgeMesh, you need to understand the following prerequisites at first:
-
-- while using DestinationRule, the name of the DestinationRule must be equal to the name of the corresponding Service. EdgeMesh will determine the DestinationRule in the same namespace according to the name of the Service
-- Service ports must be named. The key/value pairs of port name must have the following syntax: name: \<protocol>[-\<suffix>]
-
 ### Documents
 Documentation is located on [netlify.com](https://edgemesh.netlify.app/). These documents can help you understand EdgeMesh better.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -135,12 +135,6 @@ EdgeMesh-Agent 的核心组件包括：
 
 ## 指南
 
-### 预备知识
-在使用 EdgeMesh 之前，您需要先了解以下预备知识：
-
-- 使用 DestinationRule 时，要求 DestinationRule 的名字与相应的 Service 的名字要一致，EdgeMesh 会根据 Service 的名字来确定同命名空间下面的 DestinationRule
-- Service 的端口必须命名，端口名键值对必须按以下格式：name: \<protocol>[-\<suffix>]
-
 ### 文档
 EdgeMesh 在 [netlify.com](https://edgemesh.netlify.app/zh/) 托管相关文档，您可以根据这些文档更好地了解 EdgeMesh。
 

--- a/docs/guide/test-case.md
+++ b/docs/guide/test-case.md
@@ -139,7 +139,7 @@ destinationrule.networking.istio.io/hostname-lb-svc created
 ```
 
 :::tip
-EdgeMesh uses the loadBalancer property in DestinationRule to select different load balancing strategies
+EdgeMesh uses the loadBalancer property in DestinationRule to select different load balancing strategies. While using DestinationRule, the name of the DestinationRule must be equal to the name of the corresponding Service. EdgeMesh will determine the DestinationRule in the same namespace according to the name of the Service
 :::
 
 Enter the test pod and use `curl` multiple times to access the service, you will see that multiple hostname-edge are randomly accessed

--- a/docs/zh/guide/test-case.md
+++ b/docs/zh/guide/test-case.md
@@ -139,7 +139,7 @@ destinationrule.networking.istio.io/hostname-lb-svc created
 ```
 
 :::tip
-EdgeMesh 使用了 DestinationRule 中的 loadBalancer 属性来选择不同的负载均衡策略
+EdgeMesh 使用了 DestinationRule 中的 loadBalancer 属性来选择不同的负载均衡策略。使用 DestinationRule 时，要求 DestinationRule 的名字与相应的 Service 的名字要一致，EdgeMesh 会根据 Service 的名字来确定同命名空间下面的 DestinationRule
 :::
 
 进入测试容器，并多次使用 `curl` 去访问相关服务，你将看到多个 hostname-edge 被随机的访问


### PR DESCRIPTION
1. The usage rules of destinationrule should be placed in the document, and users can understand its meaning only if it is placed close to the place where it is used.
2. The restriction on configuring the port name for the service has been removed.

---

1. destinationrule的使用规则应该放在文档中，只有放在靠近使用它的地方用户才能明白其含义
2. 给服务配置port name的限制已经去除了