### PR TITLE
add a socks5 proxy

### DIFF
--- a/agent/pkg/proxy/config/config.go
+++ b/agent/pkg/proxy/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"github.com/kubeedge/edgemesh/common/util"
+)
+
 // EdgeProxyConfig indicates the edgeproxy config
 type EdgeProxyConfig struct {
 	// Enable indicates whether enable edgeproxy
@@ -13,11 +17,30 @@ type EdgeProxyConfig struct {
 	// ListenPort indicates the listen port of edgeproxy
 	// default 40001
 	ListenPort int `json:"listenPort,omitempty"`
+	// Socks5Proxy indicates the Socks5Proxy config
+	Socks5Proxy Socks5Proxy `json:"socks5Proxy,omitempty"`
+	// NodeName indicates name of host
+	NodeName string `json:"nodeName,omitempty"`
+}
+
+// Socks5Proxy indicates the Socks5Proxy config
+type Socks5Proxy struct {
+	// Enable indicates whether enable socks5 proxy server
+	// default false
+	Enable bool `json:"enable,omitempty"`
+	// ListenPort indicates the listen port of Socks5Proxy
+	// default 10800
+	ListenPort int `json:"listenPort,omitempty"`
 }
 
 func NewEdgeProxyConfig() *EdgeProxyConfig {
 	return &EdgeProxyConfig{
 		Enable:     false,
 		ListenPort: 40001,
+		NodeName:   util.FetchNodeName(),
+		Socks5Proxy: Socks5Proxy{
+			Enable:     false,
+			ListenPort: 10800,
+		},
 	}
 }

--- a/agent/pkg/proxy/module.go
+++ b/agent/pkg/proxy/module.go
@@ -14,9 +14,10 @@ import (
 
 // EdgeProxy is used for traffic proxy
 type EdgeProxy struct {
-	Config   *config.EdgeProxyConfig
-	TCPProxy *protocol.TCPProxy
-	Proxier  *Proxier
+	Config      *config.EdgeProxyConfig
+	TCPProxy    *protocol.TCPProxy
+	Proxier     *Proxier
+	Socks5Proxy *Socks5Proxy
 	// TODO(Poorunga) realize the proxy of UDP protocol
 	// UDPProxy *protocol.UDPProxy
 }
@@ -47,6 +48,14 @@ func newEdgeProxy(c *config.EdgeProxyConfig, ifm *informers.Manager) (proxy *Edg
 	proxy.Proxier, err = NewProxier(proxy.Config.SubNet, protoProxies, ifm.GetKubeClient())
 	if err != nil {
 		return proxy, fmt.Errorf("new proxier err: %v", err)
+	}
+
+	// new socks5 proxy
+	if proxy.Config.Socks5Proxy.Enable {
+		proxy.Socks5Proxy, err = NewSocks5Proxy(listenIP, proxy.Config.Socks5Proxy.ListenPort, proxy.Config.NodeName, ifm.GetKubeClient())
+		if err != nil {
+			return proxy, fmt.Errorf("new socks5Proxy err: %w", err)
+		}
 	}
 
 	return proxy, nil

--- a/agent/pkg/proxy/proxy.go
+++ b/agent/pkg/proxy/proxy.go
@@ -26,6 +26,10 @@ type sockAddr struct {
 func (proxy *EdgeProxy) Run() {
 	// ensure iptables
 	proxy.Proxier.Start()
+	// start sock5 proxy
+	if proxy.Config.Socks5Proxy.Enable {
+		proxy.Socks5Proxy.Start()
+	}
 
 	// start tcp proxy
 	for {

--- a/agent/pkg/proxy/socks5_proxy.go
+++ b/agent/pkg/proxy/socks5_proxy.go
@@ -1,0 +1,289 @@
+package proxy
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/klog/v2"
+
+	"github.com/kubeedge/edgemesh/agent/pkg/proxy/protocol"
+	"github.com/kubeedge/edgemesh/agent/pkg/tunnel"
+	"github.com/kubeedge/edgemesh/common/constants"
+)
+
+const (
+	LabelKubeedge string = "kubeedge=edgemesh-agent"
+	AgentPodName  string = "edgemesh-agent"
+
+	// Version is socks5 version
+	Version byte = 0x05
+
+	// DefaultMethod is No certification required
+	DefaultMethod byte = 0x00
+
+	Success byte = 0x00
+
+	// ATYPIPv4 is ipv4 address type
+	ATYPIPv4 byte = 0x01 // 4 octets
+	// ATYPDomain is domain address type
+	ATYPDomain byte = 0x03 // The first octet of the address field contains the number of octets of name that follow, there is no terminating NUL octet.
+	// ATYPIPv6 is ipv6 address type
+	ATYPIPv6 byte = 0x04 // 16 octets
+
+	// CmdConnect is connect command
+	CmdConnect byte = 0x01
+)
+
+// DefaultResponse is Socks5 returns data by default
+var DefaultResponse = []byte{Version, Success, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+
+// copy form https://github.com/txthinking/socks5/blob/e03c1217a50bd1363a2aaf58290da622256704fa/socks5.go#from L86 and update
+type Request struct {
+	Version     byte
+	Command     byte
+	Rsv         byte
+	AddressType byte
+	DstAddr     string
+	DstPort     int32
+}
+
+type SocksHandle struct {
+	Request *Request
+}
+
+type Socks5Proxy struct {
+	TCPProxy    *protocol.TCPProxy
+	kubeClient  kubernetes.Interface
+	NodeName    string
+	SocksHandle *SocksHandle
+}
+
+func (s *SocksHandle) ParsingConnect(conn net.Conn) (err error) {
+	err = s.handShake(conn)
+	if err != nil {
+		return err
+	}
+
+	err = s.NewRequest(conn)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// copy from https://github.com/txthinking/socks5/blob/e03c1217a50bd1363a2aaf58290da622256704fa/server_side.go#L18 and update
+func (s *SocksHandle) handShake(conn net.Conn) (err error) {
+	data := make([]byte, 2)
+	_, err = conn.Read(data)
+	if err != nil {
+		return err
+	}
+
+	if data[0] != Version {
+		return fmt.Errorf("invalid version")
+	}
+
+	if data[1] == 0 {
+		return fmt.Errorf("method length error")
+	}
+
+	ms := make([]byte, int(data[1]))
+	_, err = conn.Read(ms)
+	if err != nil {
+		return err
+	}
+
+	flag := false
+	var m byte
+	for _, m = range ms {
+		if m == DefaultMethod {
+			flag = true
+		}
+	}
+	if !flag {
+		return fmt.Errorf("this method is not yet supported")
+	}
+
+	_, err = conn.Write([]byte{Version, Success})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// copy from https://github.com/txthinking/socks5/blob/e03c1217a50bd1363a2aaf58290da622256704fa/server_side.go#L125 and update
+func (s *SocksHandle) NewRequest(conn net.Conn) (err error) {
+	data := make([]byte, 4)
+	_, err = conn.Read(data)
+	if err != nil {
+		return err
+	}
+
+	if data[0] != Version {
+		return fmt.Errorf("invalid version")
+	}
+
+	var addr []byte
+	var host string
+	if data[3] == ATYPIPv4 {
+		addr = make([]byte, 4)
+		if _, err := conn.Read(addr); err != nil {
+			return err
+		}
+		host = net.IP(addr).String()
+	} else if data[3] == ATYPIPv6 {
+		addr = make([]byte, 16)
+		if _, err := conn.Read(addr); err != nil {
+			return err
+		}
+		host = net.IP(addr).String()
+	} else if data[3] == ATYPDomain {
+		dal := make([]byte, 1)
+		if _, err := conn.Read(dal); err != nil {
+			return err
+		}
+
+		addr = make([]byte, int(dal[0]))
+		if _, err := conn.Read(addr); err != nil {
+			return err
+		}
+		host = string(addr)
+	} else {
+		return fmt.Errorf("destination address is incorrect")
+	}
+
+	port := make([]byte, 2)
+	if _, err := conn.Read(port); err != nil {
+		return err
+	}
+
+	s.Request = &Request{
+		data[0],
+		data[1],
+		data[2],
+		data[3],
+		host,
+		int32(binary.BigEndian.Uint16(port)),
+	}
+	return nil
+}
+
+func (s *Socks5Proxy) Start() {
+	go func() {
+		for {
+			conn, err := s.TCPProxy.Listener.Accept()
+			if err != nil {
+				klog.Warningf("get socks5 tcp conn error: %v", err)
+				continue
+			}
+			go s.HandleSocksProxy(conn)
+		}
+	}()
+}
+
+func NewSocks5Proxy(ip net.IP, port int, NodeName string, kubeClient kubernetes.Interface) (socks5Proxy *Socks5Proxy, err error) {
+	socks := &Socks5Proxy{
+		kubeClient: kubeClient,
+		TCPProxy:   &protocol.TCPProxy{Name: protocol.TCP},
+		NodeName:   NodeName,
+		SocksHandle: &SocksHandle{
+			Request: &Request{},
+		},
+	}
+
+	if err := socks.TCPProxy.SetListener(ip, port); err != nil {
+		return socks, fmt.Errorf("set socks5 proxy err: %v, host: %s, port: %d", err, ip, port)
+	}
+	return socks, nil
+}
+
+func pipe(dst io.WriteCloser, src io.ReadCloser, closeOnce *sync.Once) {
+	_, err := io.Copy(dst, src)
+	if err != nil && err != io.EOF && !strings.Contains(err.Error(), constants.ConnectionClosed) && !strings.Contains(err.Error(), constants.StreamReset) {
+		klog.Errorf("io copy between proxy and client error: %v", err)
+	}
+	closeOnce.Do(func() {
+		dst.Close()
+		src.Close()
+	})
+}
+
+func (s *Socks5Proxy) HandleSocksProxy(conn net.Conn) {
+	if conn == nil {
+		return
+	}
+	defer conn.Close()
+
+	err := s.SocksHandle.ParsingConnect(conn)
+
+	if err != nil {
+		klog.Errorf("Request parsing error. %v", err)
+		return
+	}
+
+	if s.SocksHandle.Request.AddressType != ATYPDomain || s.SocksHandle.Request.DstAddr == s.NodeName {
+		klog.Warningf("Connecting to the local computer and connecting via IP are not supported. host: %s, port: %d, localNodeName: %s", s.SocksHandle.Request.DstAddr, s.SocksHandle.Request.DstPort, s.NodeName)
+		return
+	}
+
+	targetIP, err := s.getTargetIpByNodeName(s.SocksHandle.Request.DstAddr)
+	if err != nil {
+		klog.Errorf("Unable to get destination IP, %v", err)
+		return
+	}
+	klog.Info("Successfully get destination IP. NodeIP: ", targetIP, ", Port: ", s.SocksHandle.Request.DstPort)
+
+	if s.SocksHandle.Request.Command == CmdConnect {
+		proxyConnectToRemote(s.SocksHandle.Request.DstAddr, targetIP, s.SocksHandle.Request.DstPort, conn)
+	} else {
+		klog.Warningf("this method is not yet supported. command: %v", s.SocksHandle.Request.Command)
+	}
+}
+
+func proxyConnectToRemote(host string, targetIP string, port int32, conn net.Conn) {
+	stream, err := tunnel.Agent.TCPProxySvc.GetProxyStream(host, targetIP, port)
+	if err != nil {
+		klog.Errorf("l4 proxy get proxy stream from %s error: %w", host, err)
+		return
+	}
+
+	klog.Infof("l4 proxy start proxy data between tcpserver %v", host)
+	_, err = conn.Write(DefaultResponse)
+	if err != nil {
+		klog.Errorf("return corresponding data error: %v", err)
+	}
+
+	closeOnce := &sync.Once{}
+	go pipe(conn, stream, closeOnce)
+	pipe(stream, conn, closeOnce)
+
+	klog.Infof("Success proxy to %v", host)
+}
+
+// getTargetIpByNodeName Returns the real IP address of the node
+// We must obtain the real IP address of the node to communicate, so we need to query the IP address of the edgemesh-agent on the node
+// Because users may modify the IP addresses of edgemesh-0 and edgecore. If used directly, it may cause errors
+func (s *Socks5Proxy) getTargetIpByNodeName(nodeName string) (targetIP string, err error) {
+	pods, err := s.kubeClient.CoreV1().Pods(constants.EdgeMeshNamespace).List(context.Background(), metav1.ListOptions{FieldSelector: "spec.nodeName=" + nodeName, LabelSelector: LabelKubeedge})
+	if err != nil {
+		return "", err
+	}
+	ip, err := "", fmt.Errorf("edgemesh agent not found on node [%s]", nodeName)
+	for _, pod := range pods.Items {
+		if strings.Contains(pod.Name, AgentPodName) {
+			ip = pod.Status.PodIP
+			err = nil
+		}
+	}
+
+	return ip, err
+}


### PR DESCRIPTION
Add a socks5 proxy to support cloud SSH login to the edge.

Documentation： [doc](https://github.com/kubeedge/edgemesh/issues/204)

Usage：
```
   ssh -o "ProxyCommand nc --proxy-type socks5 --proxy {$edgemesh-ip}:10800 {$nodeName} {$port}" root@any-ip

```

edgemesh IP defaults to 169.254.96.16