### PR TITLE
modify the labels of services filtered by edgemesh

### DIFF
--- a/docs/advanced/hybirdnat.md
+++ b/docs/advanced/hybirdnat.md
@@ -4,60 +4,32 @@
 
 When both `kube-proxy` and `edgemesh` are deployed in the cluster, the compatibility of the two is ensured by the following methods:
 
-When `edgemesh-agent` is started after `kube-proxy`, the customized `EDGE-MESH` chain will be inserted into the `PREROUTING` and `OUTPUT` chains in the nat table of the host iptables. This enables `edgemesh-agent` to hijack service traffic in priority over `kube-proxy` to achieve cloud-edge communication traffic forwarding.
+When `edgemesh-agent` is started after `kube-proxy`, the custom `EDGEMESH-` chain will be inserted into the `PREROUTING` and `OUTPUT` chains in the nat table of the host iptables, which can take precedence over `kube-proxy` hijacks the traffic of the service and realizes the traffic forwarding of cloud-edge communication.
 
 ```shell
-Chain PREROUTING (policy ACCEPT 2167 packets, 135K bytes)
-num   pkts bytes target     prot opt in     out     source               destination
-1    2655K  338M EDGE-MESH  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* edgemesh root chain */
-2    2656K  338M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
-
-Chain OUTPUT (policy ACCEPT 3825 packets, 250K bytes)
-num   pkts bytes target     prot opt in     out     source               destination
-1    7919K  508M EDGE-MESH  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* edgemesh root chain */
-2    4359K  294M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
-```
-
-
-## Traffic Proxy
-
-The `edgemesh-agent` intercepts and forwards all services accessed through the Cluster IP by default. However, the traffic forwarding process of `edgemesh-agent` will cause some performance loss in the user mode. In order to improve the efficiency of traffic forwarding, we support the ignore setting of the traffic proxy of the service, so that it uses the proxy of `kube-proxy` for traffic forwarding.
-
-**Services ignored by default**
-
-There are two cluster services that are ignored by default, namely the kube-dns(coredns) service in the kube-system namespace and the kubernetes service in the default namespace.
-
-Take the kube-dns service as an example: the program will set the ignore according to the kube-dns service with `label: k8s-app=kube-dns`, so that it can bypass `PREROUTING -> EDGE-MESH`. Then `RETURN` back to the `KUBE-SERVICES` chain set by kube-proxy, and continue traffic forwarding by the kernel's netfilter.
-
-```shell
-$ kubectl get svc -owide -nkube-system --show-labels|grep coredns
-coredns   ClusterIP   10.10.0.3    <none>        53/UDP,53/TCP,9153/TCP         20d   k8s-app=kube-dns   addonmanager.kubernetes.io/mode=Reconcile,k8s-app=kube-dns,kubernetes.io/name=coredns
-```
-
-The effect is as follows:
-
-```shell
-Chain EDGE-MESH (2 references)
+Chain PREROUTING (policy ACCEPT 1379K packets, 395M bytes)
  pkts bytes target     prot opt in     out     source               destination
-    0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.0.3           /* ignore kube-system/coredns service */
-    0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.0.1           /* ignore default/kubernetes service */
-    7   420 EDGE-MESH-TCP  tcp  --  *      *       0.0.0.0/0            10.10.0.0/16         /* tcp service proxy */
+   52 13980 EDGEMESH-PORTALS-CONTAINER  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* handle ClusterIPs; NOTE: this must be before the NodePort rules */
+1375K  394M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
+
+Chain OUTPUT (policy ACCEPT 1317K packets, 79M bytes)
+ pkts bytes target     prot opt in     out     source               destination
+   51  3086 EDGEMESH-PORTALS-HOST  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* handle ClusterIPs; NOTE: this must be before the NodePort rules */
+1314K   79M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
 ```
 
-**Customize the ignore method of other services**
+## Service Filtering
 
-You may also have some other services that you don't want to be proxied by edgemesh-agent. We have added an optional label for these services: `label: noproxy=edgemesh`, and it is recommended to configure this label for these services.
+`edgemesh-agent` intercepts and forwards all services accessed through Cluster IP by default, but the traffic forwarding process of `edgemesh-agent` will bring a little performance loss in user mode. Therefore, you may have some services that you don't want to be proxied by edgemesh-agent, we provide a label for service filtering: `service.edgemesh.kubeedge.io/service-proxy-name`.
 
-For example: if you want to deploy prometheus + grafana monitoring services in the cloud, these services do not require edge access, so you don't want them to be proxied by edgemesh-agent, then you can do:
-
-1. Edit node-exporter-service.yaml
+For example: If you want to deploy prometheus + grafana monitoring services in the cloud, these services do not require edge access, so you do not want them to be proxied by edgemesh-agent, then you can do this:
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    noproxy: edgemesh # add this label to ignored by edgemesh-agent
+    service.edgemesh.kubeedge.io/service-proxy-name: edgemesh # add this label to ignored by edgemesh-agent
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/version: v1.0.1
   name: node-exporter
@@ -72,35 +44,4 @@ spec:
     app.kubernetes.io/name: node-exporter
 ```
 
-2. Set the label similarly for other services
-
-```shell
-$ grep noproxy *
-alertmanager-service.yaml:    noproxy: edgemesh
-grafana-service.yaml:    noproxy: edgemesh
-kube-state-metrics-service.yaml:    noproxy: edgemesh
-node-exporter-service.yaml:    noproxy: edgemesh
-prometheus-adapter-service.yaml:    noproxy: edgemesh
-prometheus-service.yaml:    noproxy: edgemesh
-```
-
-The effect is as follows, these related services will be set to `RETURN` to return to the next chain of `EDGE-MESH`, namely `KUBE-SERVICES` for traffic forwarding:
-
-```shell
-Chain EDGE-MESH (4 references)
-num   pkts bytes target     prot opt in     out     source               destination
-1        1    60 RETURN     all  --  *      *       0.0.0.0/0            10.244.3.58          /* ignore monitoring/prometheus-operator service */
-2    89726 5384K RETURN     all  --  *      *       0.0.0.0/0            10.10.120.87         /* ignore monitoring/prometheus-k8s service */
-3        0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.250.210        /* ignore monitoring/grafana service */
-4        0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.212.0          /* ignore monitoring/prometheus-adapter service */
-5    21481 2496K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.38       /* ignore monitoring/node-exporter service */
-6    42917 4863K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.37       /* ignore monitoring/node-exporter service */
-7    22626 2428K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.26       /* ignore monitoring/node-exporter service */
-8     370K   33M RETURN     all  --  *      *       0.0.0.0/0            192.168.132.21       /* ignore monitoring/node-exporter service */
-9    37099 4060K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.19       /* ignore monitoring/node-exporter service */
-10       1    60 RETURN     all  --  *      *       0.0.0.0/0            10.244.3.61          /* ignore monitoring/kube-state-metrics service */
-11       0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.161.16         /* ignore monitoring/alertmanager-main service */
-12   45443 2726K RETURN     all  --  *      *       0.0.0.0/0            10.10.0.3            /* ignore kube-system/coredns service */
-13    2953  177K RETURN     all  --  *      *       0.0.0.0/0            10.10.0.1            /* ignore default/kubernetes service */
-14      62  3720 EDGE-MESH-TCP  tcp  --  *      *       0.0.0.0/0            10.10.0.0/16         /* tcp service proxy */
-```
+After saving the configuration, you will not see the iptables rules for this service in the `EDGEMESH-` chain, meaning edgemesh will not process this service.

--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -57,7 +57,7 @@ EdgeMesh satisfies the new requirements in edge scenarios (e.g., limited edge re
   </tr>
   <tr>
     <td align="center">UDP</td>
-    <td align="center">+</td>
+    <td align="center">✓</td>
   </tr>
   <tr>
     <td rowspan="3" align="center">Load Balance</td>

--- a/docs/zh/advanced/hybirdnat.md
+++ b/docs/zh/advanced/hybirdnat.md
@@ -4,60 +4,32 @@
 
 集群同时部署了 `kube-proxy` 和 `edgemesh` 时，通过下面的方式保证了两者的兼容：
 
-当 `edgemesh-agent` 后于 `kube-proxy` 启动的时候，会将自定义的 `EDGE-MESH` 链插入到主机 iptables 的 nat 表中的 `PREROUTING` 和 `OUTPUT` 链上，进而可以优先于 `kube-proxy` 劫持服务的流量，实现云边通信的流量转发。
+当 `edgemesh-agent` 后于 `kube-proxy` 启动的时候，会将自定义的 `EDGEMESH-` 链插入到主机 iptables 的 nat 表中的 `PREROUTING` 和 `OUTPUT` 链上，进而可以优先于 `kube-proxy` 劫持服务的流量，实现云边通信的流量转发。
 
 ```shell
-Chain PREROUTING (policy ACCEPT 2167 packets, 135K bytes)
-num   pkts bytes target     prot opt in     out     source               destination
-1    2655K  338M EDGE-MESH  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* edgemesh root chain */
-2    2656K  338M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
-
-Chain OUTPUT (policy ACCEPT 3825 packets, 250K bytes)
-num   pkts bytes target     prot opt in     out     source               destination
-1    7919K  508M EDGE-MESH  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* edgemesh root chain */
-2    4359K  294M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
-```
-
-
-## 流量代理
-
-`edgemesh-agent` 默认拦截并代理转发所有通过 Cluster IP 访问的服务，不过 `edgemesh-agent` 的流量转发过程在用户态中，会带来些许的性能损耗。为提高流量转发效率，我们支持对服务的流量代理进行忽略设置，使其采用 `kube-proxy` 的代理进行流量转发。
-
-**默认被忽略的服务**
-
-目前有两个集群服务是默认被忽略的，分别是 kube-system 命名空间下的 kube-dns(coredns) 服务，以及 default 命名空间下的 kubernetes 服务。
-
-以 kube-dns 服务为例子：程序会根据服务存在 `label: k8s-app=kube-dns` 的 kube-dns 服务来为其进行设置忽略，使其可以绕过 `PREROUTING -> EDGE-MESH`，再 `RETURN` 回到 kube-proxy 设置的 `KUBE-SERVICES` 链，继续由内核的 netfilter 进行流量转发。
-
-```shell
-$ kubectl get svc -owide -nkube-system --show-labels|grep coredns
-coredns   ClusterIP   10.10.0.3    <none>        53/UDP,53/TCP,9153/TCP         20d   k8s-app=kube-dns   addonmanager.kubernetes.io/mode=Reconcile,k8s-app=kube-dns,kubernetes.io/name=coredns
-```
-
-效果如下:
-
-```shell
-Chain EDGE-MESH (2 references)
+Chain PREROUTING (policy ACCEPT 1379K packets, 395M bytes)
  pkts bytes target     prot opt in     out     source               destination
-    0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.0.3           /* ignore kube-system/coredns service */
-    0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.0.1           /* ignore default/kubernetes service */
-    7   420 EDGE-MESH-TCP  tcp  --  *      *       0.0.0.0/0            10.10.0.0/16         /* tcp service proxy */
+   52 13980 EDGEMESH-PORTALS-CONTAINER  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* handle ClusterIPs; NOTE: this must be before the NodePort rules */
+1375K  394M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
+
+Chain OUTPUT (policy ACCEPT 1317K packets, 79M bytes)
+ pkts bytes target     prot opt in     out     source               destination
+   51  3086 EDGEMESH-PORTALS-HOST  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* handle ClusterIPs; NOTE: this must be before the NodePort rules */
+1314K   79M KUBE-SERVICES  all  --  *      *       0.0.0.0/0            0.0.0.0/0            /* kubernetes service portals */
 ```
 
-**自定义其他服务的忽略方法**
+## 服务过滤
 
-你可能还会有一些其他的服务不想被 edgemesh-agent 代理，我们为这些服务增加了一个可选项的标签: `label: noproxy=edgemesh`，并建议为这些服务配置该标签。
+`edgemesh-agent` 默认拦截并转发所有通过 Cluster IP 访问的服务，不过 `edgemesh-agent` 的流量转发过程在用户态中，会带来些许的性能损耗。因此，你可能会有一些服务不想被 edgemesh-agent 代理，我们为服务过滤提供了一个标签: `service.edgemesh.kubeedge.io/service-proxy-name`。
 
 举个例子：比如你想在云端部署 prometheus + grafana 监控服务，这些服务不需要边缘端的访问，所以你并不希望它们被 edgemesh-agent 代理，那么你可以这么做：
-
-1. 编辑 node-exporter-service.yaml
 
 ```yaml
 apiVersion: v1
 kind: Service
 metadata:
   labels:
-    noproxy: edgemesh # add this label to ignored by edgemesh-agent
+    service.edgemesh.kubeedge.io/service-proxy-name: "" # add this label to ignored by edgemesh-agent
     app.kubernetes.io/name: node-exporter
     app.kubernetes.io/version: v1.0.1
   name: node-exporter
@@ -72,35 +44,4 @@ spec:
     app.kubernetes.io/name: node-exporter
 ```
 
-2. 类似的为其他服务也设置该标签
-
-```shell
-$ grep noproxy *
-alertmanager-service.yaml:    noproxy: edgemesh
-grafana-service.yaml:    noproxy: edgemesh
-kube-state-metrics-service.yaml:    noproxy: edgemesh
-node-exporter-service.yaml:    noproxy: edgemesh
-prometheus-adapter-service.yaml:    noproxy: edgemesh
-prometheus-service.yaml:    noproxy: edgemesh
-```
-
-效果如下，相关这些服务将被设置为 `RETURN` 回到 `EDGE-MESH` 的下一条链，即 `KUBE-SERVICES` 来进行流量转发:
-
-```shell
-Chain EDGE-MESH (4 references)
-num   pkts bytes target     prot opt in     out     source               destination
-1        1    60 RETURN     all  --  *      *       0.0.0.0/0            10.244.3.58          /* ignore monitoring/prometheus-operator service */
-2    89726 5384K RETURN     all  --  *      *       0.0.0.0/0            10.10.120.87         /* ignore monitoring/prometheus-k8s service */
-3        0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.250.210        /* ignore monitoring/grafana service */
-4        0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.212.0          /* ignore monitoring/prometheus-adapter service */
-5    21481 2496K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.38       /* ignore monitoring/node-exporter service */
-6    42917 4863K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.37       /* ignore monitoring/node-exporter service */
-7    22626 2428K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.26       /* ignore monitoring/node-exporter service */
-8     370K   33M RETURN     all  --  *      *       0.0.0.0/0            192.168.132.21       /* ignore monitoring/node-exporter service */
-9    37099 4060K RETURN     all  --  *      *       0.0.0.0/0            192.168.132.19       /* ignore monitoring/node-exporter service */
-10       1    60 RETURN     all  --  *      *       0.0.0.0/0            10.244.3.61          /* ignore monitoring/kube-state-metrics service */
-11       0     0 RETURN     all  --  *      *       0.0.0.0/0            10.10.161.16         /* ignore monitoring/alertmanager-main service */
-12   45443 2726K RETURN     all  --  *      *       0.0.0.0/0            10.10.0.3            /* ignore kube-system/coredns service */
-13    2953  177K RETURN     all  --  *      *       0.0.0.0/0            10.10.0.1            /* ignore default/kubernetes service */
-14      62  3720 EDGE-MESH-TCP  tcp  --  *      *       0.0.0.0/0            10.10.0.0/16         /* tcp service proxy */
-```
+保存配置后，你将不会在 `EDGEMESH-` 链里看到这个服务的 iptables 规则，意味着 edgemesh 不会对此服务进行处理。

--- a/docs/zh/guide/README.md
+++ b/docs/zh/guide/README.md
@@ -58,7 +58,7 @@ EdgeMesh 满足边缘场景下的新需求（如边缘资源有限、边云网�
   </tr>
   <tr>
     <td align="center">UDP</td>
-    <td align="center">+</td>
+    <td align="center">✓</td>
   </tr>
   <tr>
     <td rowspan="3" align="center">负载均衡</td>


### PR DESCRIPTION
Because the filter label of kube-proxy is `service.kubernetes.io/service-proxy-name`, in order to unify the format, the filter label of edgemesh is changed to: `service.edgemesh.kubeedge.io/service-proxy-name`