### PR TITLE
Remove the code that closes defer rconn.Close()

### DIFF
--- a/agent/pkg/chassis/protocol/tcp/handler.go
+++ b/agent/pkg/chassis/protocol/tcp/handler.go
@@ -75,7 +75,6 @@ func (h *L4ProxyHandler) Handle(chain *handler.Chain, i *invocation.Invocation, 
 			r.Err = fmt.Errorf("l4 proxy dial error: %v", err)
 			return
 		}
-		defer rconn.Close()
 
 		if tcpProtocol.UpgradeReq != nil {
 			_, err = rconn.Write(tcpProtocol.UpgradeReq)


### PR DESCRIPTION
fix #323 