### PR TITLE
pick a correct endpoint when there are more than one port in a service and strategy is consistent hash 

### DIFF
--- a/third_party/forked/kubernetes/pkg/proxy/userspace/loadbalancer.go
+++ b/third_party/forked/kubernetes/pkg/proxy/userspace/loadbalancer.go
@@ -17,7 +17,7 @@ import (
 type LoadBalancer interface {
 	// NextEndpoint returns the endpoint to handle a request for the given
 	// service-port and source address.
-	NextEndpoint(service proxy.ServicePortName, srcAddr net.Addr, netConn *net.TCPConn, sessionAffinityReset bool) (string, *http.Request, error)
+	NextEndpoint(service proxy.ServicePortName, srcAddr net.Addr, netConn net.Conn, sessionAffinityReset bool) (string, *http.Request, error)
 	NewService(service proxy.ServicePortName, sessionAffinityType v1.ServiceAffinity, stickyMaxAgeSeconds int) error
 	DeleteService(service proxy.ServicePortName)
 	CleanupStaleStickySessions(service proxy.ServicePortName)

--- a/third_party/forked/kubernetes/pkg/proxy/userspace/loadbalancer_ex_test.go
+++ b/third_party/forked/kubernetes/pkg/proxy/userspace/loadbalancer_ex_test.go
@@ -1,0 +1,118 @@
+package userspace
+
+import (
+	"strings"
+	"testing"
+
+	"istio.io/api/meta/v1alpha1"
+	"istio.io/api/networking/v1alpha3"
+	istioapi "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/proxy"
+)
+
+func TestConsistentHashStrategy(t *testing.T) {
+	lb := NewLoadBalancerEX()
+	nodeName := "node1"
+	const ns = "ns"
+	const svc = "myservice"
+	const portName1 = "mqtt"
+	const portName2 = "http"
+	lb.OnEndpointsAdd(&v1.Endpoints{
+		TypeMeta: metav1.TypeMeta{Kind: "Endpoints"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      svc,
+			Namespace: ns,
+		},
+		Subsets: []v1.EndpointSubset{{
+			Addresses: []v1.EndpointAddress{{
+				IP:       "192.168.0.1",
+				Hostname: "pod1",
+				NodeName: &nodeName,
+				TargetRef: &v1.ObjectReference{
+					Kind:      "Pod",
+					Namespace: ns,
+					Name:      "mypod-787756668b-6gczj",
+				},
+			},
+				{
+					IP:       "192.168.0.2",
+					Hostname: "pod2",
+					NodeName: &nodeName,
+					TargetRef: &v1.ObjectReference{
+						Kind:      "Pod",
+						Namespace: ns,
+						Name:      "mypod-787756668b-6gczi",
+					},
+				}},
+			NotReadyAddresses: nil,
+			Ports: []v1.EndpointPort{{
+				Name:     portName1,
+				Port:     1883,
+				Protocol: "tcp",
+			},
+				{
+					Name:     portName2,
+					Port:     80,
+					Protocol: "tcp",
+				}},
+		}},
+	})
+
+	namespacedName := types.NamespacedName{Namespace: ns, Name: svc}
+	svcPortName1 := proxy.ServicePortName{NamespacedName: namespacedName, Port: portName1}
+	svcPortName2 := proxy.ServicePortName{NamespacedName: namespacedName, Port: portName2}
+
+	serviceCheck := func(svcPortName proxy.ServicePortName) {
+		if state, ok := lb.services[svcPortName]; ok {
+			if len(state.endpoints) != 2 {
+				t.Errorf("length of endpoints of ServicePortName %v should be 2", svcPortName)
+			}
+		} else {
+			t.Errorf("ServicePortName %v should exist", svcPortName)
+		}
+	}
+
+	serviceCheck(svcPortName1)
+	serviceCheck(svcPortName2)
+
+	lb.OnDestinationRuleAdd(&istioapi.DestinationRule{
+		TypeMeta:   metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: svc},
+		Spec: v1alpha3.DestinationRule{
+			TrafficPolicy: &v1alpha3.TrafficPolicy{
+				LoadBalancer: &v1alpha3.LoadBalancerSettings{
+					LbPolicy: &v1alpha3.LoadBalancerSettings_ConsistentHash{},
+				},
+			},
+		},
+		Status: v1alpha1.IstioStatus{},
+	})
+
+	strategyCheck := func(svcPortName proxy.ServicePortName, port string) {
+		if _, ok := lb.strategyMap[svcPortName].(*ConsistentHashStrategy); !ok {
+			t.Errorf("strategy of %v should be consistent hash", svcPortName1)
+			return
+		}
+
+		ep, _, err := lb.NextEndpoint(
+			svcPortName,
+			nil,
+			nil,
+			false,
+		)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		parts := strings.Split(ep, ":")
+		if len(parts) != 4 || parts[3] != port {
+			t.Errorf("a wrong endpoint picked for ServicePortName %v", svcPortName)
+		}
+	}
+
+	strategyCheck(svcPortName1, "1883")
+	strategyCheck(svcPortName2, "80")
+}

--- a/third_party/forked/kubernetes/pkg/proxy/userspace/loadbalancer_strategy.go
+++ b/third_party/forked/kubernetes/pkg/proxy/userspace/loadbalancer_strategy.go
@@ -27,7 +27,7 @@ const (
 type LoadBalancerStrategy interface {
 	Name() string
 	Update(oldDr, dr *istioapi.DestinationRule)
-	Pick(endpoints []string, srcAddr net.Addr, tcpConn *net.TCPConn) (string, *http.Request, error)
+	Pick(endpoints []string, srcAddr net.Addr, tcpConn net.Conn) (string, *http.Request, error)
 	Sync(endpoints []string)
 	Release()
 }
@@ -75,7 +75,7 @@ func (*RoundRobinStrategy) Name() string {
 
 func (*RoundRobinStrategy) Update(oldDr, dr *istioapi.DestinationRule) {}
 
-func (*RoundRobinStrategy) Pick(endpoints []string, srcAddr net.Addr, tcpConn *net.TCPConn) (string, *http.Request, error) {
+func (*RoundRobinStrategy) Pick(endpoints []string, srcAddr net.Addr, netConn net.Conn) (string, *http.Request, error) {
 	// RoundRobinStrategy is an empty implementation and we won't use it,
 	// the outer round-robin strategy will be used next.
 	return "", nil, fmt.Errorf("call RoundRobinStrategy is forbidden")
@@ -99,7 +99,7 @@ func (rd *RandomStrategy) Name() string {
 
 func (rd *RandomStrategy) Update(oldDr, dr *istioapi.DestinationRule) {}
 
-func (rd *RandomStrategy) Pick(endpoints []string, srcAddr net.Addr, tcpConn *net.TCPConn) (string, *http.Request, error) {
+func (rd *RandomStrategy) Pick(endpoints []string, srcAddr net.Addr, netConn net.Conn) (string, *http.Request, error) {
 	rd.lock.Lock()
 	k := rand.Int() % len(endpoints)
 	rd.lock.Unlock()
@@ -294,22 +294,22 @@ func (ch *ConsistentHashStrategy) Update(oldDr, dr *istioapi.DestinationRule) {
 	ch.lock.Unlock()
 }
 
-func (ch *ConsistentHashStrategy) Pick(endpoints []string, srcAddr net.Addr, tcpConn *net.TCPConn) (endpoint string, req *http.Request, err error) {
+func (ch *ConsistentHashStrategy) Pick(endpoints []string, srcAddr net.Addr, netConn net.Conn) (endpoint string, req *http.Request, err error) {
 	ch.lock.Lock()
 	defer ch.lock.Unlock()
 
 	var keyValue string
 	switch ch.hashKey.Type {
 	case HttpHeader:
-		req, err = http.ReadRequest(bufio.NewReader(tcpConn))
+		req, err = http.ReadRequest(bufio.NewReader(netConn))
 		if err != nil {
 			klog.Errorf("read http request err: %v", err)
 			return "", nil, err
 		}
 		keyValue = req.Header.Get(ch.hashKey.Key)
 	case UserSourceIP:
-		if srcAddr == nil && tcpConn != nil {
-			srcAddr = tcpConn.RemoteAddr()
+		if srcAddr == nil && netConn != nil {
+			srcAddr = netConn.RemoteAddr()
 		}
 		keyValue = srcAddr.String()
 	default:


### PR DESCRIPTION
Issue: If there are more than one port in a service and the strategy is consistent hash, only the endpoints of the first port will be used to build the hash ring. Then if comes a request to another port, a wrong endpoint from the hash ring picked. #343 

Fix: cache loadbalance strategy for every service port and build the hash ring for every service port if the strategy is consistent hash.