### PR TITLE
Add libp2p stream limit settting

### DIFF
--- a/pkg/apis/config/defaults/default.go
+++ b/pkg/apis/config/defaults/default.go
@@ -58,4 +58,9 @@ const (
 
 	FilterIfLabelExistsMode        ServiceFilterMode = "FilterIfLabelExists"
 	FilterIfLabelDoesNotExistsMode ServiceFilterMode = "FilterIfLabelDoesNotExists"
+
+	TunnelBaseStreamIn      int = 10240
+	TunnelBaseStreamOut     int = 10240
+	TunnelPeerBaseStreamIn  int = 1024
+	TunnelPeerBaseStreamOut int = 1024
 )

--- a/pkg/apis/config/v1alpha1/default.go
+++ b/pkg/apis/config/v1alpha1/default.go
@@ -56,6 +56,13 @@ var defaultEdgeTunnelConfig = &EdgeTunnelConfig{
 		Enable: true,
 		Path:   defaults.PSKPath,
 	},
+	TunnelLimitConfig: &TunnelLimitConfig{
+		Enable:                  true,
+		TunnelBaseStreamIn:      defaults.TunnelBaseStreamIn,
+		TunnelBaseStreamOut:     defaults.TunnelBaseStreamOut,
+		TunnelPeerBaseStreamIn:  defaults.TunnelPeerBaseStreamIn,
+		TunnelPeerBaseStreamOut: defaults.TunnelPeerBaseStreamOut,
+	},
 }
 
 // NewDefaultEdgeMeshAgentConfig returns a full EdgeMeshAgentConfig object

--- a/pkg/apis/config/v1alpha1/types.go
+++ b/pkg/apis/config/v1alpha1/types.go
@@ -257,6 +257,8 @@ type EdgeTunnelConfig struct {
 	FinderPeriod int `json:"finderPeriod,omitempty"`
 	// PSK configures libp2p to use the given private network protector.
 	PSK *PSK `json:"psk,omitempty"`
+	// TunnelLimitConfig configures tunnel stream limit
+	TunnelLimitConfig *TunnelLimitConfig `json:"tunnelLimitConfig,omitempty"`
 }
 
 type RelayNode struct {
@@ -273,4 +275,22 @@ type PSK struct {
 	// Path indicates the psk file path.
 	// default /etc/edgemesh/psk
 	Path string `json:"path,omitempty"`
+}
+
+type TunnelLimitConfig struct {
+	// Enable indicates whether libp2p ResourceLimit is enabled,
+	// defaults true
+	Enable bool `json:"enable,omitempty"`
+	// Tunnel Proxy all Stream InBound count
+	// default:10240
+	TunnelBaseStreamIn int `json:"tunnelBaseStreamIn,omitempty"`
+	// Tunnel Proxy all Stream OutBound count
+	// default:10240
+	TunnelBaseStreamOut int `json:"tunnelBaseStreamOut,omitempty"`
+	// Tunnel Proxy each Peer Stream InBound count
+	// default:1024
+	TunnelPeerBaseStreamIn int `json:"tunnelPeerBaseStreamIn,omitempty"`
+	// Tunnel Proxy each Peer Stream OutBound count
+	// default:1024
+	TunnelPeerBaseStreamOut int `json:"tunnelPeerBaseStreamOut,omitempty"`
 }

--- a/pkg/tunnel/limit.go
+++ b/pkg/tunnel/limit.go
@@ -1,0 +1,71 @@
+package tunnel
+
+import (
+	"math"
+
+	"github.com/libp2p/go-libp2p"
+	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+
+	"github.com/kubeedge/edgemesh/pkg/apis/config/defaults"
+	"github.com/kubeedge/edgemesh/pkg/apis/config/v1alpha1"
+)
+
+func useLimit(config *v1alpha1.TunnelLimitConfig) *rcmgr.ScalingLimitConfig {
+	scalingLimits := rcmgr.DefaultLimits
+	protoLimit := rcmgr.BaseLimit{
+		Streams:         config.TunnelBaseStreamIn + config.TunnelBaseStreamOut,
+		StreamsInbound:  config.TunnelBaseStreamIn,
+		StreamsOutbound: config.TunnelBaseStreamOut,
+		FD:              rcmgr.DefaultLimits.ProtocolBaseLimit.FD,
+		Memory:          rcmgr.DefaultLimits.ProtocolBaseLimit.Memory,
+	}
+	scalingLimits.AddProtocolLimit(defaults.ProxyProtocol, protoLimit, rcmgr.DefaultLimits.ProtocolLimitIncrease)
+	scalingLimits.ProtocolPeerBaseLimit.Streams = config.TunnelPeerBaseStreamIn + config.TunnelPeerBaseStreamOut
+	scalingLimits.ProtocolPeerBaseLimit.StreamsOutbound = config.TunnelPeerBaseStreamOut
+	scalingLimits.ProtocolPeerBaseLimit.StreamsInbound = config.TunnelPeerBaseStreamIn
+	return &scalingLimits
+}
+func useNoLimit() *rcmgr.ScalingLimitConfig {
+	scalingLimits := rcmgr.DefaultLimits
+	protoLimit := rcmgr.BaseLimit{
+		Streams:         math.MaxInt,
+		StreamsInbound:  math.MaxInt,
+		StreamsOutbound: math.MaxInt,
+		FD:              rcmgr.DefaultLimits.ProtocolBaseLimit.FD,
+		Memory:          rcmgr.DefaultLimits.ProtocolBaseLimit.Memory,
+	}
+	scalingLimits.AddProtocolLimit(defaults.ProxyProtocol, protoLimit, rcmgr.BaseLimitIncrease{})
+	scalingLimits.ProtocolPeerBaseLimit.Streams = math.MaxInt
+	scalingLimits.ProtocolPeerBaseLimit.StreamsOutbound = math.MaxInt
+	scalingLimits.ProtocolPeerBaseLimit.StreamsInbound = math.MaxInt
+	scalingLimits.ProtocolPeerLimitIncrease = rcmgr.BaseLimitIncrease{}
+	return &scalingLimits
+}
+
+func buildLimitOpt(scalingLimits *rcmgr.ScalingLimitConfig) (libp2p.Option, error) {
+	// Add limits around included libp2p protocols
+	libp2p.SetDefaultServiceLimits(scalingLimits)
+	// Turn the scaling limits into a static set of limits using `.AutoScale`. This
+	// scales the limits proportional to your system memory.
+	limits := scalingLimits.AutoScale()
+	// The resource manager expects a limiter, se we create one from our limits.
+	limiter := rcmgr.NewFixedLimiter(limits)
+	// Initialize the resource manager
+	if rm, err := rcmgr.NewResourceManager(limiter); err != nil {
+		return nil, err
+	} else {
+		return libp2p.ResourceManager(rm), nil
+	}
+}
+
+func CreateLimitOpt(config *v1alpha1.TunnelLimitConfig) (libp2p.Option, error) {
+	// Start with the default scaling limits.
+	var scaleLimit *rcmgr.ScalingLimitConfig
+	// Adjust limit if need:
+	if !config.Enable {
+		scaleLimit = useNoLimit()
+	} else {
+		scaleLimit = useLimit(config)
+	}
+	return buildLimitOpt(scaleLimit)
+}

--- a/pkg/tunnel/module.go
+++ b/pkg/tunnel/module.go
@@ -151,7 +151,10 @@ func newEdgeTunnel(c *v1alpha1.EdgeTunnelConfig) (*EdgeTunnel, error) {
 		libp2p.EnableNATService(),
 		libp2p.EnableHolePunching(),
 	}...)
-
+	//Adjust stream limit
+	if limitOpt, err := CreateLimitOpt(c.TunnelLimitConfig); err == nil {
+		opts = append(opts, limitOpt)
+	}
 	h, err := libp2p.New(opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to new p2p host: %w", err)


### PR DESCRIPTION
What type of PR is this?

/kind feature Add libp2p stream limit settting

对libp2p stream扩展为默认可配置项
libp2p的resourcemanger默认的对所有的protocol进行流的限制。
[https://github.com/libp2p/go-libp2p/blob/master/p2p/host/resource-manager/limit_defaults.go](url)
参考源码，libp2p对protocol协议的限制主要分为以下两种:
1、针对协议的入栈出栈的流个数的限制
2、针对协议的每一个peer入栈出栈的流个数进行限制
最终针对协议的最终流个数限制为：
基础流个数+scale的扩展流个数。scale的扩展会根据每GB内存大小进行额外的扩容。
将基础流个数作为可配置项，并且设置为默认值，防止在中继过程中，遇到流被重置的问题。实测默认情况下，4-5个网页会触发stream reset。

