### PR TITLE
close p2p stream when error occur or this stream will be not used

### DIFF
--- a/pkg/loadbalancer/loadbalancer.go
+++ b/pkg/loadbalancer/loadbalancer.go
@@ -13,7 +13,7 @@ import (
 	istioapi "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istio "istio.io/client-go/pkg/clientset/versioned"
 	istioinformers "istio.io/client-go/pkg/informers/externalversions"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -927,6 +927,7 @@ func (lb *LoadBalancer) TryConnectEndpoints(service proxy.ServicePortName, srcAd
 			if err == nil {
 				_, err = outConn.Write(reqBytes)
 				if err != nil {
+					outConn.Close()
 					return nil, err
 				}
 			}

--- a/pkg/proxy/proxysocket.go
+++ b/pkg/proxy/proxysocket.go
@@ -184,6 +184,7 @@ func (udp *udpProxySocket) getBackendConn(activeClients *userspace.ClientCache, 
 			return nil, err
 		}
 		if err = svrConn.SetDeadline(time.Now().Add(timeout)); err != nil {
+			svrConn.Close()
 			klog.ErrorS(err, "SetDeadline failed")
 			return nil, err
 		}

--- a/pkg/util/net/conn.go
+++ b/pkg/util/net/conn.go
@@ -55,6 +55,7 @@ func copyBytes(direction string, dest, src net.Conn, wg *sync.WaitGroup) {
 }
 
 func ProxyConnUDP(inConn net.Conn, udpConn *net.UDPConn) {
+	defer inConn.Close()
 	var buffer [4096]byte
 	for {
 		n, err := inConn.Read(buffer[0:])

--- a/pkg/util/tunutils/tun.go
+++ b/pkg/util/tunutils/tun.go
@@ -323,6 +323,7 @@ func Dial() (*TunConn, error) { return nil, nil }
 func DialTun(stream net.Conn, name string) {
 	p2p2Tun, err := NewTunConn(name)
 	if err != nil {
+		stream.Close()
 		klog.Errorf("p2p handler create TunConn failed", err)
 		return
 	}
@@ -331,6 +332,7 @@ func DialTun(stream net.Conn, name string) {
 	buffer := NewRecycleByteBuffer(PacketSize)
 	// TODO: separate below as P2P handler and add SetWriteDeadline
 	go func() {
+		defer stream.Close()
 		for {
 			n, err := stream.Read(packet)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/kubeedge/blob/master/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

When edgemeshA create a p2p stream to edgemeshB, if error occur in edgemeshA or edgemeshB, or this stream will be not used, the stream resource should be released in edgemeshA and edgemeshB. 

refer to go-libp2p code and examples. I add stream.Close or stream.Reset in edgemesh.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #567

**Special notes for your reviewer**: none

**Does this PR introduce a user-facing change?**: no
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```
